### PR TITLE
ls-4613 Correction of spelling errors and revision of dioxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 
 # ls.exe
----
-_**ls**_ is a replacement for the _**dir**_ command, it is inspired by the unix [ls command](https://en.wikipedia.org/wiki/Ls) to list the content of directory.
+
+_**ls**_ is a replacement for the _**dir**_ command, it is inspired by the Unix [ls command](https://en.wikipedia.org/wiki/Ls) to list the content of directory.
 
 ![Screenshots of ls](resources/screenshot.jpg)
 
----
 ## Table of Contents
 - [Features](#features)
 - [Usage](#usage)
@@ -14,18 +13,16 @@ _**ls**_ is a replacement for the _**dir**_ command, it is inspired by the unix 
 - [Donations](#donations)
 - [License](#license)
 
----
-# Features
+## Features
 * Show file type `d` for directory, `l` for symbolic link, `-` any other type
 * Show user file permissions `r` for read, `w` for write, `x` execution and `-` no permission
 * File size displayed in Bytes, MegaBytes, etc. `-` if size can not be retrieved
 * To which group the file belongs or `-` if it can not be retrieved
 * The owner of the file or `-` if it can not be retrieved
-* Creation / Access / Modification date, by default creation in case of short use the sort date
-* Icons, currently hardcoded, use [Nerd Fonts](https://github.com/ryanoasis/nerd-fonts), you console has to be able to display [UTF-8](https://en.wikipedia.org/wiki/UTF-8)
+* Creation / Access / Modification date, by default creation in case of sort uses the sort date
+* Icons, currently hard-coded, uses [Nerd Fonts](https://github.com/ryanoasis/nerd-fonts), your console has to be able to display [UTF-8](https://en.wikipedia.org/wiki/UTF-8)
 
----
-# Usage
+## Usage
 ```
 Usage
   ls.exe [options] [files...]
@@ -78,8 +75,7 @@ function List-Dir()
 Set-Alias -name 'ls' -value List-Dir -Option AllScope
 ```
 
----
-# Project distribution
+## Project distribution
 ```
 | -> utils
     | -> cl.bat             Searching and loading visual studio environment [vcvars.bat]
@@ -95,11 +91,10 @@ Set-Alias -name 'ls' -value List-Dir -Option AllScope
     | -> screenshot.jpg     Screenshot used on this README
 ```
 
----
-# Roadmap
+## Roadmap
 * Consider configuration file for colors and icons
----
-# Donations
+
+## Donations
 This is free, open-source software. If you'd like to support the development of future projects, or say thanks for this one, you can donate:
 | Crypto | Address | Network |
 |----------|:-------------:|------:|
@@ -107,6 +102,5 @@ This is free, open-source software. If you'd like to support the development of 
 | ETH | 0x8e249fb24e71459184c836f9fc53d32f09d44555 | ERC20 |
 | USDT | TXkofuYzGiLTS6GP2K2RMKJ4y6xqBZV8Pf | TRC20 |
 
----
-# License
+## License
 ls.exe is distributed under the terms of the Apache License Version 2.0. A complete version of the license is available in the [LICENSE.md](LICENSE.md) in this repository. Any contribution made to this project will be licensed under the Apache License Version 2.0.

--- a/source/directory.h
+++ b/source/directory.h
@@ -7,7 +7,7 @@
  * for the asset name, the wild card is represented by '*'.
  * ex: C:\Windows\System32\*.dll
  *
- * @param directory         pointer to the directory path
+ * @param directory         char pointer to the directory path
  * @param arguments         pointer to the parsed arguments structure
  * @return directory_t*     container with the assets information or NULL otherwise
  */

--- a/source/ls.c
+++ b/source/ls.c
@@ -36,12 +36,11 @@ static BOOL  g_PrintWithColor = FALSE;  // Colorize the output or not
 ///////////////////////////////////////////////////////////////////////////////
 
 /**
- * @brief Prints a text on the screen with a given color.
- * if the global variable 'g_PrintWithColor' is not set
- * the text it will be printed using the default console
- * text color.
+ * @brief Prints text on the screen with a given color. If the global variable
+ * 'g_PrintWithColor' is not set the text it will be printed using the default
+ * console text color.
  *
- * @param textColor text color, see 'ETextColor'
+ * @param textColor text color, see 'ETextColor' (types.h)
  * @param fmt       format of the text or the text itself
  * @param ...       variable arguments list
  */
@@ -77,10 +76,9 @@ static void color_printf(text_color_t textColor, const char *fmt, ...)
 }
 
 /**
- * @brief Prints a text on the screen with a given color.
- * if the global variable 'g_PrintWithColor' is not set
- * the text it will be printed using the default console
- * text color.
+ * @brief Prints text on the screen with a given color. If the global variable
+ * 'g_PrintWithColor' is not set the text it will be printed using the default
+ * console text color.
  *
  * It makes use of the Virtual Console sequence
  * https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
@@ -119,14 +117,14 @@ static void color_printf_vt(int r, int g, int b, const char *fmt, ...)
 
 /**
  * @brief Given an asset with its properties return the color used for
- * printing based on the asset attributes.
+ * printing based on the asset type.
  *
- * Default color is WHITE. * Directories will be print as GREEN.
+ * Default color is WHITE. Directories will be print as GREEN.
  * Encrypted files as BLUE, compress files as MAGENTA, temporary
  * as DARKGREY, system files as RED and symbolic kink as CYAN.
  *
  * @param asset         pointer to the asset (file or directory)
- * @return ETextColor   the color used to print
+ * @return ETextColor   the color used fpr printing
  */
 static text_color_t GetTextNameColor(const asset_t *asset)
 {
@@ -161,14 +159,14 @@ static text_color_t GetTextNameColor(const asset_t *asset)
 }
 
 /**
- * @brief Given an asset return char with its representation.
+ * @brief Given an asset, return char with its representation.
  * It tells us if is a directory, symbolic link or other type.
  *
  * 'd' for directory
  * 'l' for symbolic links
  * '-' for any other format
  *
- * @param data      pointer to the asset (file or directory)
+ * @param data      pointer to the asset data structure
  * @return char     'd', 'l' or '-'
  */
 static char GetContentType(const asset_t *data)
@@ -183,12 +181,11 @@ static char GetContentType(const asset_t *data)
 }
 
 /**
- * @brief Get the icon based on the asset extension or attributes.
- * If the extension is not found a predefined icon for based
- * on the attributes it will be given.
+ * @brief Get the metadata based on the asset extension. If the extension is not
+ * found a predefined metadata based on the type it will be returned.
  *
- * @param data          pointer to the asset (file or directory)
- * @return const char*  utf-8 encoding of the icon
+ * @param data                      valid pointer to the asset
+ * @return const asset_metadata_t*  pointer to the metadata structure
  */
 static const asset_metadata_t *GetAssetMetadata(const asset_t *data)
 {

--- a/source/ls.c
+++ b/source/ls.c
@@ -124,7 +124,7 @@ static void color_printf_vt(int r, int g, int b, const char *fmt, ...)
  * as DARKGREY, system files as RED and symbolic kink as CYAN.
  *
  * @param asset         pointer to the asset (file or directory)
- * @return ETextColor   the color used fpr printing
+ * @return ETextColor   the color used for printing
  */
 static text_color_t GetTextNameColor(const asset_t *asset)
 {

--- a/source/types.h
+++ b/source/types.h
@@ -6,7 +6,6 @@
 #define STARTUP_CONTAINER_SIZE  128  // startup capacity of the list container
 
 #define PATH_SIZE MAX_PATH          // number of characters used for the path
-#define PATTERN_SIZE    32          // number of characters used for the search pattern
 #define DATE_SIZE       32          // number of characters used for the date
 
 #define DOMAIN_SIZE 32              // number of characters used for the user domain (group)
@@ -38,7 +37,7 @@ typedef enum text_color_t
 } text_color_t;
 
 /**
- * @brief Enumerator telling which sort has to be applied.
+ * @brief Enumerator indicating what kind of sorting should be applied.
  */
 typedef enum sort_by_e
 {
@@ -58,15 +57,8 @@ typedef enum sort_by_e
 
 ///////////////////////////////////////////////////////////////////////////////
 
-typedef struct path_t
-{
-    char path[PATH_SIZE];
-    char pattern[PATTERN_SIZE];
-} path_t;
-
 /**
- * @brief Contains the user access rights
- * for a given asset for the current user.
+ * @brief User access rights for a given asset.
  *
  * 'read'       : read permissions      'r'
  * 'write'      : write permissions     'w'
@@ -80,8 +72,8 @@ typedef struct access_rights_t
 } access_rights_t;
 
 /**
- * @brief Has information about the asset type.
- * it could be a directory, a document or symlink.
+ * @brief Information about the asset type.
+ * it could be a directory, document, symlink, etc
  */
 typedef struct asset_type_t
 {
@@ -99,12 +91,12 @@ typedef struct asset_type_t
 } asset_type_t;
 
 /**
- * @brief Information about the creation time,
- * last modification, etc of the asset.
+ * @brief Information about the creation date,
+ * last modification and write of the asset.
  *
  * 'access'         : last time it was accessed
  * 'creation'       : asset creation timestamp
- * 'modification'   : last time it as modify
+ * 'modification'   : last time it was modify
  */
 typedef struct timestamp_t
 {
@@ -115,16 +107,19 @@ typedef struct timestamp_t
 
 /**
  * @brief It contains the main information of an asset.
- * By asset we understand file or directory.
+ * By asset we understand document or directory.
  *
  * 'accessRights'   : see 'access_rights_t' structure
- * 'asset_type_t'   : type of the asset (hidden, symlink, temporal, directory, etc)
- * 'timestamp'      : FILETIME timestamp, creation, modification ,etc
+ * 'type'           : see 'asset_type_t' structure
+ *
+ * 'timestamp'      : FILETIME timestamp, creation, modification, based on sorting (by default creation)
  * 'size'           : size in bytes (only for files, directory don't have size)
  *
- * 'date'           : creation date
+ * 'date'           : creation | accessed | modified date, based on sorting (by default creation)
  * 'name'           : name of the asset
+ *
  * 'link'           : only for symlinks, contains the real path
+ * 'path'           : full path to the asset
  *
  * 'domain'         : domain of the asset owner
  * 'owner'          : owner of the asset
@@ -160,7 +155,7 @@ typedef struct directory_t
 } directory_t;
 
 /**
- * @brief Linked list that contains the directory to list.
+ * @brief Linked list that contains the directories to list.
  *
  * 'next'   pointer to the next directory to list
  * 'path'   current directory path to list
@@ -172,20 +167,21 @@ typedef struct directory_list_t
 } directory_list_t;
 
 /**
- * @brief It has the program arguments.
+ * @brief Contais information of the user input arguments.
  *
- * 'showAll'                : '-a', '--all'         show all assets found
+ * 'showAll'                : '-a', '--all'         show all assets found, '.', '..'  and hidden included
  * 'showMetaData'           : '-l', '--long'        show extra information as size, creation date, permissions, etc
+ * 'showAlmostAll'          : '-A', '--almost-all'  show all assets found, hidden included but not '.' and '..'
  *
  * 'reverseOrder'           : '-r', '--reverse'     reverse the sort order
  * 'recursiveList'          : '-R', '--recursive'   recursive list folders
  *
- * 'colors'                 : '--colors'            colorize the output
- * 'showIcons'              : '--icons'             show icons related to the asset
+ * 'colors'                 :       '--colors'      colorize the output
+ * 'showIcons'              :       '--icons'       show icons related to the asset
  *
  * 'showHelp'               : '-?', '--help'        show list of commands available
  * 'showVersion'            : '-v', '--version'     show current version number
- * 'showAvailableIcons'     : '--sai'               display icons and the file extensions
+ * 'showAvailableIcons'     :       '--sai'         display icons and the file extensions
  *
  * 'sortField'              :                       which field is used to sort (name, size, owner, group, etc)
  * 'currentDir', 'lastDir'  :                       linked list of the directories to list
@@ -213,7 +209,12 @@ typedef struct arguments_t
 } arguments_t;
 
 /**
- * @brief Data structure containing the associated icon of a file extension.
+ * @brief Data structure containing the associated icon of a file extension
+ * and it's color. The RGB color it is only used with virtual terminal.
+ *
+ * 'r'    : red color
+ * 'g'    : green color
+ * 'b'    : blue color
  *
  * 'ext'  : extension name, has to include the dot '.'
  * 'icons': UTF-8 string representation the icon

--- a/source/types.h
+++ b/source/types.h
@@ -229,6 +229,34 @@ typedef struct asset_metadata_t
 
 static const asset_metadata_t g_AssetMetaData[] =
 {
+    // System predefined directory
+    {230,  57,  70, "windows",             u8"\ue70f"},
+    {168, 218, 220, "users",               u8"\uf74b"},
+    {168, 218, 220, "program files",       u8"\uf756"},
+    {168, 218, 220, "program files (x86)", u8"\uf756"},
+
+    // User predefined directory
+    {168, 218, 220, "contacts",  u8"\ufbc9"},
+    {168, 218, 220, "desktop",   u8"\uf108"},
+    {168, 218, 220, "documents", u8"\uf752"},
+    {168, 218, 220, "downloads", u8"\uf498"},
+    {168, 218, 220, "favorites", u8"\ufb9b"},
+    {168, 218, 220, "links",     u8"\uf0c1"},
+    {168, 218, 220, "music",     u8"\uf883"},
+    {168, 218, 220, "videos",    u8"\ufa66"},
+    {168, 218, 220, "pictures",  u8"\uf74e"},
+
+    // Other type of folders
+    {243, 114, 44, ".git",              u8"\ue702"},
+    {243, 114, 44, ".gitconfig",        u8"\ue702"},
+    {243, 114, 44, ".gitignore",        u8"\ue702"},
+    {243, 114, 44, ".gitattributes",    u8"\ue702"},
+    {249, 132, 74, ".config",           u8"\ue5fc"},
+    {255, 182,  0, "license.md",        u8"\ue60a"},
+    {255, 182,  0, "license",           u8"\ue60a"},
+    {255, 158,  0, "readme.md",         u8"\uf7fc"},
+    {255, 158,  0, "readme",            u8"\uf7fc"},
+
     // Windows executable and libraries
     {229, 107, 111, ".exe", u8"\ufb13"},
     {181, 101, 118, ".dll", u8"\uf1e1"},
@@ -319,6 +347,9 @@ static const asset_metadata_t g_AssetMetaData[] =
     { 39, 125, 161, ".json",         u8"\ufb25"},
     {249, 132,  74, ".xml",          u8"\uf72d"},
     {249, 132,  74, ".ini",          u8"\ue615"},
+    {249, 132,  74, ".cfg",          u8"\ue615"},
+    {166, 117, 161, ".yml",          u8"\ue009"},
+    {239, 217, 206, ".md",           u8"\uf853"},
 
     // Fonts
     {144, 190, 109, ".ttf",   u8"\uf031"},
@@ -361,26 +392,5 @@ static const asset_metadata_t g_AssetMetaData[] =
     {249, 199, 79, ".tlog",  u8"\uf18d"},
     {249, 199, 79, ".msql",  u8"\uf1c0"},
     {249, 199, 79, ".mysql", u8"\uf1c0"},
-    {249, 199, 79, ".cache", u8"\uf1c0" },
-
-    // System predefined directory
-    {230,  57,  70, "windows",             u8"\ue70f"},
-    {168, 218, 220, "users",               u8"\uf74b"},
-    {168, 218, 220, "program files",       u8"\uf756"},
-    {168, 218, 220, "program files (x86)", u8"\uf756"},
-
-    // User predefined directory
-    {168, 218, 220, "contacts",  u8"\ufbc9"},
-    {168, 218, 220, "desktop",   u8"\uf108"},
-    {168, 218, 220, "documents", u8"\uf752"},
-    {168, 218, 220, "downloads", u8"\uf498"},
-    {168, 218, 220, "favorites", u8"\ufb9b"},
-    {168, 218, 220, "links",     u8"\uf0c1"},
-    {168, 218, 220, "music",     u8"\uf883"},
-    {168, 218, 220, "videos",    u8"\ufa66"},
-    {168, 218, 220, "pictures",  u8"\uf74e"},
-
-    // Other type of folders
-    {243, 114, 44, ".git",    u8"\ue5fb"},
-    {249, 132, 74, ".config", u8"\ue5fc"}
+    {249, 199, 79, ".cache", u8"\uf1c0"}
 };

--- a/source/utils.h
+++ b/source/utils.h
@@ -51,24 +51,24 @@ BOOL StringEndsWith(const char *str, const char *suffix);
 
 /**
  * @brief Given a filename, extract directory from filename.
- * If no directory is found the current working directory
- * will be returned.
+ * By default it will return the filename if path can not be
+ * extracted.
  *
  * @param path          name of the file to extract the directory
- * @param buffer        buffer char array where data is stored
+ * @param buffer        char array where data is stored
  * @param bufferSize    size in bytes of the buffer
- * @return const char*  pointer to the buffer array if directory extracted, NULL otherwise
+ * @return const char*  pointer to the buffer array if directory extracted
  */
 const char *GetDirectoryFromPath(const char *path, char *buffer, size_t bufferSize);
 
 /**
  * @brief Get a human readable representation for the size,
- * if the size is zero a hyphen it will shown instead.
- * print sizes like 1K 234M 2G etc.
+ * if the size is zero a hyphen it will shown instead,
+ * print sizes like 1K / 234M / 2G / etc.
  *
  * This function can not multi-threaded as it has a
  * static member variable to store the file size
- * as string.
+ * as string and returns a pointer to it.
  *
  * @param bytes         size of the asset in bytes
  * @return const char*  human readable representation
@@ -84,10 +84,10 @@ const char *GetFileSizeAsText(size_t bytes);
 const char *GetWorkingDirectory();
 
 /**
- * @brief Given a path it ways it is current path, '.',
+ * @brief Given a path it says it is current path, '.',
  * or parent path, '..'.
  *
  * @param path      relative path
- * @return BOOL     TRUE if it
+ * @return BOOL     TRUE if it is '.' or '..', FALSE otherwise
  */
 BOOL IsDotPath(const char *path);

--- a/source/win32.c
+++ b/source/win32.c
@@ -104,7 +104,7 @@ void GetPermissions(const char *path, asset_t *asset)
     CHECK_CLOSE_HANDLE(hImpersonatedToken);
 }
 
-BOOL GetOwnerAndDomain(const char *assetPath, asset_t *asset)
+BOOL GetOwnerAndDomain(const char *path, asset_t *asset)
 {
     PSID pSidOwner = NULL;
     PSECURITY_DESCRIPTOR pSD = NULL;
@@ -112,7 +112,7 @@ BOOL GetOwnerAndDomain(const char *assetPath, asset_t *asset)
     strcpy_s(asset->owner, OWNER_SIZE, "-");
     strcpy_s(asset->domain, DOMAIN_SIZE, "-");
 
-    HANDLE hFile = CreateFileA(assetPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    HANDLE hFile = CreateFileA(path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile == INVALID_HANDLE_VALUE) { GetLastErrorAsString(); return FALSE; }
 
     DWORD dwRtnCode = GetSecurityInfo(hFile, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &pSidOwner, NULL, NULL, NULL, &pSD);

--- a/source/win32.h
+++ b/source/win32.h
@@ -16,18 +16,18 @@ void GetPermissions(const char *path, asset_t *asset);
  * @brief Get the owner and the owner domain of the asset.
  * By default an hyphen it will be show.
  *
- * @param assetPath full path of the asset
+ * @param path      full path of the asset
  * @param asset     pointer of the asset data structure where information is stored
  * @return BOOL     TRUE if owner and domain can be retrieved, FALSE otherwise
  */
-BOOL GetOwnerAndDomain(const char *assetPath, asset_t *asset);
+BOOL GetOwnerAndDomain(const char *path, asset_t *asset);
 
 /**
- * @brief Get symbolic link real path
+ * @brief Get symbolic link real path.
  *
  * @param path      full path of the symbolic link
  * @param asset     pointer of the asset data structure where information is stored
- * @return BOOL     TRUE is path found, FALSE otherwise
+ * @return BOOL     TRUE is path can be retrieved, FALSE otherwise
  */
 BOOL GetLinkTarget(const char *path, asset_t *asset);
 
@@ -42,7 +42,7 @@ void TranslateAttributes(size_t attributes, asset_t *asset);
 /**
  * @brief Given a path it says is the valid directory or not.
  *
- * @param path  full directory path
+ * @param path  full path
  * @return BOOL TRUE is valid, FALSE otherwise
  */
 BOOL IsValidDirectory(const char *path);
@@ -50,13 +50,15 @@ BOOL IsValidDirectory(const char *path);
 /**
  * @brief Given a path it says is the valid document or not.
  *
- * @param path  full document path
+ * @param path  full path
  * @return BOOL TRUE is valid, FALSE otherwise
  */
 BOOL IsValidDocument(const char *path);
 
 /**
- * @brief Get the full size of the asset. By default size is split
+ * @brief Translate the Win32 file size format to bytes size.
+ *
+ * By default size is split
  * in 2 parts, low and high. (high * (MAXDWORD+1)) + low
  *
  * @param fd        pointer to a valid WIN32_FIND_DATAA data structure
@@ -65,13 +67,13 @@ BOOL IsValidDocument(const char *path);
 size_t TranslateFileSize(WIN32_FIND_DATAA *fd);
 
 /**
- * @brief Enable virtual terminal
+ * @brief Enable virtual terminal.
  * https://docs.microsoft.com/es-es/windows/console/console-virtual-terminal-sequences
  */
 BOOL EnableVirtualTerminal();
 
 /**
- * @brief Disable virtual terminal
+ * @brief Disable virtual terminal.
  * https://docs.microsoft.com/es-es/windows/console/console-virtual-terminal-sequences
  */
 BOOL DisableVirtualTerminal();


### PR DESCRIPTION
# Description
Review the README and the source code and check for misspelling words or changes on the dioxygen documentation.

# Root cause
Reviewing the source code, discrepancies between the code and the documentation have been observed as well as spelling errors in the README.

# Solution
Change the dioxygen documentation to describe the source code and fix the misspelling errors.