### PR TITLE
ls-1528 improve display of meta data information

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ TIPS
 If you are using Command Prompt take into consideration to make an [alias using doskey](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/doskey) with the parameters you mostly find useful in your day to day. For Powershell make a function in your profile script and bind it to an [alias using Set-Alias](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-alias?view=powershell-7.2) name.
 
 ```cmd
-Command prompt
+# Command prompt
 doskey ls=ls.exe --icons --colors --virterm --group-directories-first $*
 ```
 
 ```powershell
-Powershell
+# Powershell
 function List-Dir()
 {
     ls.exe --icons --colors --virterm --group-directories-first @args
@@ -74,6 +74,8 @@ function List-Dir()
 
 Set-Alias -name 'ls' -value List-Dir -Option AllScope
 ```
+
+There is an extra hidden option, `--smd` (show metadata), which shows a list of available extensions with their color and icon for each.
 
 ## Project distribution
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ function List-Dir()
 Set-Alias -name 'ls' -value List-Dir -Option AllScope
 ```
 
-There is an extra hidden option, `--smd` (show metadata), which shows a list of available extensions with their color and icon for each.
+There is an extra hidden option, `--smd` (show metadata), which shows a list of available extensions with their color and icon of each.
+
+```text
+# Output format
+(r, g, b)  icons  extension
+```
 
 ## Project distribution
 ```

--- a/source/ls.c
+++ b/source/ls.c
@@ -247,8 +247,8 @@ static void ParseShortArgument(const char *arg, arguments_t *arguments)
         switch (*c)
         {
             case 'A': arguments->showAlmostAll = arguments->showAll = TRUE; break;
+            case 'l': arguments->showLongFormat = TRUE; break;
             case 'R': arguments->recursiveList = TRUE; break;
-            case 'l': arguments->showMetaData = TRUE; break;
             case 'r': arguments->reverseOrder = TRUE; break;
             case 'v': arguments->showVersion = TRUE; break;
             case '?': arguments->showHelp = TRUE; break;
@@ -294,7 +294,7 @@ static const char **ParseLongArgument(const char **arg, arguments_t *arguments)
     }
     else if (strcmp(*arg, "--long") == 0)
     {
-        arguments->showMetaData = TRUE;
+        arguments->showLongFormat = TRUE;
     }
     else if (strcmp(*arg, "--help") == 0)
     {
@@ -312,10 +312,10 @@ static const char **ParseLongArgument(const char **arg, arguments_t *arguments)
     {
         arguments->showAll = TRUE;
     }
-    else if (strcmp(*arg, "--sai") == 0)
+    else if (strcmp(*arg, "--smd") == 0)
     {
         arguments->showIcons = TRUE;
-        arguments->showAvailableIcons = TRUE;
+        arguments->showMetaData = TRUE;
     }
     else if (strcmp(*arg, "--sort") == 0)
     {
@@ -411,7 +411,7 @@ static void PrintAssetInformation(const directory_t *content, const char *direct
     size_t ownerLength = 0, domainLength = 0;
     size_t directoryLength = strlen(currentPath);
 
-    for (size_t i = 0; i < content->size && arguments->showMetaData; ++i)
+    for (size_t i = 0; i < content->size && arguments->showLongFormat; ++i)
     {
         size_t s = strlen(content->data[i].domain);
         domainLength = domainLength < s ? s : domainLength;
@@ -422,7 +422,7 @@ static void PrintAssetInformation(const directory_t *content, const char *direct
 
     for (size_t i = 0; i < content->size; ++i)
     {
-        if (!arguments->showMetaData)
+        if (!arguments->showLongFormat)
         {
             text_color_t textColor = GetTextNameColor(&content->data[i]);
             color_printf(textColor, "%s\n", content->data[i].name);
@@ -538,7 +538,7 @@ int main(int argc, char *argv[])
         printf_s("Can not enable virtual terminal.\n\n");
     }
 
-    if (arguments.showAvailableIcons)
+    if (arguments.showMetaData)
     {
         for (size_t i = 0; i < ARRAY_SIZE(g_AssetMetaData); ++i)
         {

--- a/source/ls.c
+++ b/source/ls.c
@@ -513,6 +513,32 @@ static void PrintAssetInformation(const directory_t *content, const char *direct
     }
 }
 
+/**
+ * @brief Display the information of the available extensions. For each entry,
+ * a line will be printed with the RGB color values, the icon and the extension
+ * name. If if the possible the line will have the predefined color of the
+ * extension.
+ *
+ * @param arguments pointer to the parsed arguments structure
+ */
+static void ShowMetaData(const arguments_t *arguments)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(g_AssetMetaData); ++i)
+    {
+        const char fmt[] = "(%3d, %3d, %3d)  %s  %s\n";
+        const asset_metadata_t *m = &g_AssetMetaData[i];
+
+        if (arguments->virtualTerminal)
+        {
+            color_printf_vt(m->r, m->g, m->b, fmt, m->r, m->g, m->b, m->icon, m->ext);
+        }
+        else
+        {
+            printf_s(fmt, m->r, m->g, m->b, m->icon, m->ext);
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char *argv[])
@@ -525,6 +551,7 @@ int main(int argc, char *argv[])
     #endif
 
     arguments_t arguments = ParseArguments(argc, argv);
+    g_PrintWithColor = arguments.colors;
 
     if (arguments.showIcons && !SetConsoleOutputCP(65001))
     {
@@ -540,11 +567,7 @@ int main(int argc, char *argv[])
 
     if (arguments.showMetaData)
     {
-        for (size_t i = 0; i < ARRAY_SIZE(g_AssetMetaData); ++i)
-        {
-            printf_s("% 30s  %s\n", g_AssetMetaData[i].ext, g_AssetMetaData[i].icon);
-        }
-
+        ShowMetaData(&arguments);
         return EXIT_SUCCESS;
     }
 
@@ -565,7 +588,6 @@ int main(int argc, char *argv[])
         AddDirectoryToList(&arguments, GetWorkingDirectory());
     }
 
-    g_PrintWithColor = arguments.colors;
     BOOL extraDirs = arguments.currentDir->next != NULL || arguments.recursiveList;
 
     while (arguments.currentDir != NULL)

--- a/source/types.h
+++ b/source/types.h
@@ -170,8 +170,8 @@ typedef struct directory_list_t
  * @brief Contais information of the user input arguments.
  *
  * 'showAll'                : '-a', '--all'         show all assets found, '.', '..'  and hidden included
- * 'showMetaData'           : '-l', '--long'        show extra information as size, creation date, permissions, etc
  * 'showAlmostAll'          : '-A', '--almost-all'  show all assets found, hidden included but not '.' and '..'
+ * 'showLongFormat'         : '-l', '--long'        show extra information as size, creation date, permissions, etc
  *
  * 'reverseOrder'           : '-r', '--reverse'     reverse the sort order
  * 'recursiveList'          : '-R', '--recursive'   recursive list folders
@@ -181,7 +181,9 @@ typedef struct directory_list_t
  *
  * 'showHelp'               : '-?', '--help'        show list of commands available
  * 'showVersion'            : '-v', '--version'     show current version number
- * 'showAvailableIcons'     :       '--sai'         display icons and the file extensions
+ *
+ * 'showMetaData'           :       '--smd'         display colors, icons and the file extensions
+ * 'virtualTerminal'        :       '--virterm'     use virtual terminal for better color display
  *
  * 'sortField'              :                       which field is used to sort (name, size, owner, group, etc)
  * 'currentDir', 'lastDir'  :                       linked list of the directories to list
@@ -189,8 +191,8 @@ typedef struct directory_list_t
 typedef struct arguments_t
 {
     BOOL showAll;
-    BOOL showMetaData;
     BOOL showAlmostAll;
+    BOOL showLongFormat;
 
     BOOL reverseOrder;
     BOOL recursiveList;
@@ -201,8 +203,8 @@ typedef struct arguments_t
     BOOL showHelp;
     BOOL showVersion;
 
+    BOOL showMetaData;
     BOOL virtualTerminal;
-    BOOL showAvailableIcons;
 
     sort_by_e sortField;
     directory_list_t *currentDir, *lastDir;


### PR DESCRIPTION
## Description
Add RGB colors to the metadata command output, `--smd`, and also display the text with the predefined color for each extension.

## Testing
**Shell**: Windows Terminal 1.11.3471.0, Powershell Console and Command Prompt
**Windows**: 10, Version 19043.1503